### PR TITLE
Secure auth key APIs and update app console

### DIFF
--- a/gateway/src/api/handlers/auth_keys.rs
+++ b/gateway/src/api/handlers/auth_keys.rs
@@ -1,15 +1,16 @@
 use askama::Template;
 use axum::{
     extract::{Json, Path as AxumPath, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Response},
 };
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 
-use crate::context::NamespacedKv;
 use super::super::types::{ApiState, AuthKeysListTemplate};
+use super::sessions::has_valid_session;
+use crate::context::NamespacedKv;
 
 const AUTH_KEYS_PREFIX: &str = "auth/keys";
 
@@ -37,6 +38,7 @@ pub struct AuthKeyListItem {
 
 #[derive(Debug)]
 pub enum AuthKeyError {
+    Unauthorized,
     Storage(String),
     NotFound,
 }
@@ -44,20 +46,22 @@ pub enum AuthKeyError {
 impl IntoResponse for AuthKeyError {
     fn into_response(self) -> Response {
         match self {
+            AuthKeyError::Unauthorized => StatusCode::UNAUTHORIZED.into_response(),
             AuthKeyError::Storage(msg) => {
                 error!("Auth key storage error: {}", msg);
                 (StatusCode::INTERNAL_SERVER_ERROR, "storage error").into_response()
             }
-            AuthKeyError::NotFound => {
-                (StatusCode::NOT_FOUND, "key not found").into_response()
-            }
+            AuthKeyError::NotFound => (StatusCode::NOT_FOUND, "key not found").into_response(),
         }
     }
 }
 
 pub(crate) async fn generate_auth_key(
     State(state): State<ApiState>,
+    headers: HeaderMap,
 ) -> Result<Json<GenerateKeyResponse>, AuthKeyError> {
+    ensure_console_session(&state, &headers)?;
+
     let kv = {
         let guard = state.kv.read().expect("gateway shared kv read lock");
         guard.clone()
@@ -71,8 +75,14 @@ pub(crate) async fn generate_auth_key(
         .unwrap()
         .as_secs() as i64;
 
-    let last_chars = key.chars().rev().take(8).collect::<String>()
-        .chars().rev().collect::<String>();
+    let last_chars = key
+        .chars()
+        .rev()
+        .take(8)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
 
     let auth_key = AuthKey {
         key_id: key_id.clone(),
@@ -94,12 +104,19 @@ pub(crate) async fn generate_auth_key(
 
 pub(crate) async fn list_auth_keys(
     State(state): State<ApiState>,
+    headers: HeaderMap,
 ) -> Result<Response, AuthKeyError> {
+    ensure_console_session(&state, &headers)?;
+
     let kv = {
         let guard = state.kv.read().expect("gateway shared kv read lock");
         guard.clone()
     };
 
+    render_auth_keys_list(&kv)
+}
+
+fn render_auth_keys_list(kv: &NamespacedKv) -> Result<Response, AuthKeyError> {
     let prefix = AUTH_KEYS_PREFIX.as_bytes();
     let entries = kv
         .list_by_prefix(prefix)
@@ -140,7 +157,10 @@ pub(crate) async fn list_auth_keys(
 pub(crate) async fn revoke_auth_key(
     State(state): State<ApiState>,
     AxumPath(key_id): AxumPath<String>,
+    headers: HeaderMap,
 ) -> Result<Response, AuthKeyError> {
+    ensure_console_session(&state, &headers)?;
+
     let kv = {
         let guard = state.kv.read().expect("gateway shared kv read lock");
         guard.clone()
@@ -164,10 +184,24 @@ pub(crate) async fn revoke_auth_key(
     debug!(key_id = %key_id, "Revoked auth key");
 
     // Return updated list
-    list_auth_keys(State(state)).await
+    render_auth_keys_list(&kv)
 }
 
-pub(crate) fn validate_auth_key(kv: &NamespacedKv, provided_key: &str) -> Result<bool, ::kv::Error> {
+fn ensure_console_session(state: &ApiState, headers: &HeaderMap) -> Result<(), AuthKeyError> {
+    match has_valid_session(state, headers) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(AuthKeyError::Unauthorized),
+        Err(err) => Err(AuthKeyError::Storage(format!(
+            "failed to validate session: {}",
+            err
+        ))),
+    }
+}
+
+pub(crate) fn validate_auth_key(
+    kv: &NamespacedKv,
+    provided_key: &str,
+) -> Result<bool, ::kv::Error> {
     let prefix = AUTH_KEYS_PREFIX.as_bytes();
     let entries = kv.list_by_prefix(prefix)?;
 
@@ -201,7 +235,7 @@ fn generate_key_id() -> String {
 }
 
 fn hash_key(key: &str) -> String {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(key.as_bytes());
     hex::encode(hasher.finalize())
@@ -240,8 +274,14 @@ pub(crate) fn store_legacy_key(kv: &NamespacedKv, key: &str) -> Result<(), AuthK
         .unwrap()
         .as_secs() as i64;
 
-    let last_chars = key.chars().rev().take(8).collect::<String>()
-        .chars().rev().collect::<String>();
+    let last_chars = key
+        .chars()
+        .rev()
+        .take(8)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
 
     let auth_key = AuthKey {
         key_id: "default".to_string(),
@@ -256,22 +296,105 @@ pub(crate) fn store_legacy_key(kv: &NamespacedKv, key: &str) -> Result<(), AuthK
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::handlers::sessions::create_session;
+    use crate::api::types::{SessionRequest, SESSION_COOKIE};
     use crate::context::{initialize_kv, CommonContext};
+    use axum::http::{
+        header::{COOKIE, SET_COOKIE},
+        HeaderMap, HeaderValue,
+    };
     use std::sync::{Arc, RwLock};
     use tempfile::TempDir;
 
-    #[tokio::test]
-    async fn generate_key_creates_valid_key() {
+    fn test_state() -> (TempDir, ApiState) {
         let temp = TempDir::new().expect("tempdir");
         let kv = initialize_kv(Some(temp.path())).expect("kv init");
         let context = CommonContext::new(kv);
+        context
+            .auth
+            .create_user("console-admin", "super-secret")
+            .expect("create default user");
 
         let state = ApiState {
             kv: Arc::new(RwLock::new(context.kv.clone())),
             auth: Arc::clone(&context.auth),
         };
 
-        let response = generate_auth_key(State(state))
+        (temp, state)
+    }
+
+    async fn authenticated_headers(state: &ApiState) -> HeaderMap {
+        let response = create_session(
+            State(state.clone()),
+            Json(SessionRequest {
+                username: "console-admin".into(),
+                password: "super-secret".into(),
+            }),
+        )
+        .await
+        .expect("session creation succeeds");
+
+        let cookie_header = response
+            .headers()
+            .get(SET_COOKIE)
+            .expect("set-cookie present")
+            .to_str()
+            .expect("cookie str");
+        let token = cookie_header
+            .split(';')
+            .next()
+            .and_then(|segment| segment.strip_prefix(&format!("{}=", SESSION_COOKIE)))
+            .expect("session token present")
+            .to_string();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!("{}={}", SESSION_COOKIE, token))
+                .expect("cookie header value"),
+        );
+        headers
+    }
+
+    #[tokio::test]
+    async fn generate_key_requires_console_session() {
+        let (_temp, state) = test_state();
+
+        let err = generate_auth_key(State(state), HeaderMap::new())
+            .await
+            .expect_err("unauthenticated generation is rejected");
+
+        assert_eq!(err.into_response().status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn list_keys_requires_console_session() {
+        let (_temp, state) = test_state();
+
+        let err = list_auth_keys(State(state), HeaderMap::new())
+            .await
+            .expect_err("unauthenticated listing is rejected");
+
+        assert_eq!(err.into_response().status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn revoke_key_requires_console_session() {
+        let (_temp, state) = test_state();
+
+        let err = revoke_auth_key(State(state), AxumPath("missing".into()), HeaderMap::new())
+            .await
+            .expect_err("unauthenticated revocation is rejected");
+
+        assert_eq!(err.into_response().status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn generate_key_creates_valid_key_for_authenticated_console_user() {
+        let (_temp, state) = test_state();
+        let headers = authenticated_headers(&state).await;
+
+        let response = generate_auth_key(State(state), headers)
             .await
             .expect("generate succeeds");
 
@@ -282,20 +405,14 @@ mod tests {
 
     #[tokio::test]
     async fn list_keys_returns_generated_keys() {
-        let temp = TempDir::new().expect("tempdir");
-        let kv = initialize_kv(Some(temp.path())).expect("kv init");
-        let context = CommonContext::new(kv);
+        let (_temp, state) = test_state();
+        let headers = authenticated_headers(&state).await;
 
-        let state = ApiState {
-            kv: Arc::new(RwLock::new(context.kv.clone())),
-            auth: Arc::clone(&context.auth),
-        };
-
-        let _ = generate_auth_key(State(state.clone()))
+        let _ = generate_auth_key(State(state.clone()), headers.clone())
             .await
             .expect("generate succeeds");
 
-        let response = list_auth_keys(State(state))
+        let response = list_auth_keys(State(state), headers)
             .await
             .expect("list succeeds");
 

--- a/gateway/src/api/handlers/console.rs
+++ b/gateway/src/api/handlers/console.rs
@@ -6,7 +6,9 @@ use axum::{
 };
 use tracing::error;
 
-use super::super::types::{ApiState, DashboardTemplate, EndpointsTemplate, LoginTemplate, SettingsTemplate};
+use super::super::types::{
+    ApiState, DashboardTemplate, EndpointsTemplate, LoginTemplate, SettingsTemplate,
+};
 use super::sessions::has_valid_session;
 
 pub(crate) async fn console_root() -> Response {
@@ -19,7 +21,10 @@ pub(crate) async fn console_root() -> Response {
     }
 }
 
-pub(crate) async fn console_dashboard(State(state): State<ApiState>, headers: HeaderMap) -> Response {
+pub(crate) async fn console_dashboard(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Response {
     match has_valid_session(&state, &headers) {
         Ok(true) => match DashboardTemplate.render() {
             Ok(html) => (StatusCode::OK, Html(html)).into_response(),
@@ -40,7 +45,10 @@ pub(crate) async fn console_dashboard(State(state): State<ApiState>, headers: He
     }
 }
 
-pub(crate) async fn console_endpoints(State(state): State<ApiState>, headers: HeaderMap) -> Response {
+pub(crate) async fn console_endpoints(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Response {
     match has_valid_session(&state, &headers) {
         Ok(true) => match EndpointsTemplate.render() {
             Ok(html) => (StatusCode::OK, Html(html)).into_response(),
@@ -61,7 +69,10 @@ pub(crate) async fn console_endpoints(State(state): State<ApiState>, headers: He
     }
 }
 
-pub(crate) async fn console_settings(State(state): State<ApiState>, headers: HeaderMap) -> Response {
+pub(crate) async fn console_settings(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Response {
     match has_valid_session(&state, &headers) {
         Ok(true) => match SettingsTemplate.render() {
             Ok(html) => (StatusCode::OK, Html(html)).into_response(),
@@ -85,14 +96,14 @@ pub(crate) async fn console_settings(State(state): State<ApiState>, headers: Hea
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{CommonContext, initialize_kv};
     use crate::api::handlers::sessions::create_session;
     use crate::api::types::{SessionRequest, SESSION_COOKIE};
+    use crate::context::{initialize_kv, CommonContext};
+    use axum::http::HeaderValue;
     use axum::{
         extract::Json,
         http::header::{COOKIE, SET_COOKIE},
     };
-    use axum::http::HeaderValue;
     use std::sync::{Arc, RwLock};
     use tempfile::TempDir;
 
@@ -173,5 +184,63 @@ mod tests {
         let rendered = String::from_utf8(body_bytes.into()).expect("body utf8");
         assert!(rendered.contains("Dashboard"));
         assert!(rendered.contains("hx-get=\"/api/dashboard/endpoints\""));
+    }
+
+    #[tokio::test]
+    async fn apps_console_uses_app_and_api_key_language() {
+        let temp = TempDir::new().expect("tempdir");
+        let kv = initialize_kv(Some(temp.path())).expect("kv init");
+        let context = CommonContext::new(kv);
+        context
+            .auth
+            .create_user("console-admin", "super-secret")
+            .expect("create default user");
+
+        let state = ApiState {
+            kv: Arc::new(RwLock::new(context.kv.clone())),
+            auth: Arc::clone(&context.auth),
+        };
+
+        let response = create_session(
+            State(state.clone()),
+            Json(SessionRequest {
+                username: "console-admin".into(),
+                password: "super-secret".into(),
+            }),
+        )
+        .await
+        .expect("session creation succeeds");
+        let cookie_header = response
+            .headers()
+            .get(SET_COOKIE)
+            .expect("set-cookie present")
+            .to_str()
+            .expect("cookie str");
+        let token = cookie_header
+            .split(';')
+            .next()
+            .and_then(|segment| segment.strip_prefix(&format!("{}=", SESSION_COOKIE)))
+            .expect("session token present")
+            .to_string();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(&format!("{}={}", SESSION_COOKIE, token))
+                .expect("cookie header value"),
+        );
+
+        let response = console_endpoints(State(state), headers).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let rendered = String::from_utf8(body_bytes.into()).expect("body utf8");
+        assert!(rendered.contains("Apps"));
+        assert!(rendered.contains("API Keys"));
+        assert!(rendered.contains("Generate API Key"));
+        assert!(rendered.contains("Registered Apps"));
+        assert!(rendered.contains("/apps"));
     }
 }

--- a/gateway/src/api/mod.rs
+++ b/gateway/src/api/mod.rs
@@ -171,6 +171,7 @@ fn build_router(shared_kv: Arc<RwLock<NamespacedKv>>, auth: Arc<GatewayAuthServi
     let console_routes = Router::new()
         .route("/", get(console_root))
         .route("/dashboard", get(console_dashboard))
+        .route("/apps", get(console_endpoints))
         .route("/endpoints", get(console_endpoints))
         .route("/settings", get(console_settings));
 

--- a/gateway/templates/auth_keys_list.html
+++ b/gateway/templates/auth_keys_list.html
@@ -1,10 +1,10 @@
 {% if keys.len() == 0 %}
-<p class="dashboard-empty">No auth keys generated yet.</p>
+<p class="dashboard-empty">No API keys generated yet.</p>
 {% else %}
 <table class="dashboard-table">
   <thead>
     <tr>
-      <th>Key ID</th>
+      <th>API Key ID</th>
       <th>Last 8 Characters</th>
       <th>Created</th>
       <th>Actions</th>

--- a/gateway/templates/dashboard.html
+++ b/gateway/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Hightower · Dashboard</title>
-  <meta name="description" content="Operational view of registered endpoints within Hightower.">
+  <meta name="description" content="Operational view of registered apps within Hightower.">
   <link rel="stylesheet" href="/static/css/dashboard.css">
   <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
 </head>
@@ -27,7 +27,7 @@
         </a>
       </li>
       <li>
-        <a href="/endpoints" class="menu-item" data-page="endpoints">
+        <a href="/apps" class="menu-item" data-page="apps">
           <svg class="menu-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="10" cy="10" r="2"/>
             <circle cx="4" cy="4" r="2"/>
@@ -40,7 +40,7 @@
             <line x1="8.5" y1="11" x2="5.5" y2="14.5"/>
             <line x1="11.5" y1="11" x2="14.5" y2="14.5"/>
           </svg>
-          <span class="menu-label">Endpoints</span>
+          <span class="menu-label">Apps</span>
         </a>
       </li>
       <li>
@@ -65,12 +65,12 @@
   <main class="dashboard-main">
     <div class="page-header">
       <h1>Dashboard</h1>
-      <p>Monitor and manage registered endpoints in the mesh network.</p>
+      <p>Monitor and manage registered apps in the mesh network.</p>
     </div>
 
     <section class="content-section" aria-labelledby="dashboard-heading">
       <div class="section-header">
-        <h2 id="dashboard-heading">Registered Endpoints</h2>
+        <h2 id="dashboard-heading">Registered Apps</h2>
       </div>
       <div
         id="endpoint-list"
@@ -78,7 +78,7 @@
         hx-trigger="load, every 10s"
         hx-swap="innerHTML"
       >
-        <p class="dashboard-empty">Loading endpoint registrations…</p>
+        <p class="dashboard-empty">Loading app registrations…</p>
       </div>
     </section>
   </main>
@@ -107,7 +107,7 @@
     document.querySelectorAll('.menu-item').forEach(item => {
       const page = item.getAttribute('data-page');
       if ((page === 'dashboard' && currentPath === '/dashboard') ||
-          (page === 'endpoints' && currentPath === '/endpoints') ||
+          (page === 'apps' && (currentPath === '/apps' || currentPath === '/endpoints')) ||
           (page === 'settings' && currentPath === '/settings')) {
         item.classList.add('active');
       }

--- a/gateway/templates/endpoints.html
+++ b/gateway/templates/endpoints.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Hightower · Endpoints</title>
-  <meta name="description" content="Manage and configure endpoints in the Hightower mesh.">
+  <title>Hightower · Apps</title>
+  <meta name="description" content="Manage apps and API keys in the Hightower mesh.">
   <link rel="stylesheet" href="/static/css/dashboard.css">
   <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
 </head>
@@ -27,7 +27,7 @@
         </a>
       </li>
       <li>
-        <a href="/endpoints" class="menu-item" data-page="endpoints">
+        <a href="/apps" class="menu-item" data-page="apps">
           <svg class="menu-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="10" cy="10" r="2"/>
             <circle cx="4" cy="4" r="2"/>
@@ -40,7 +40,7 @@
             <line x1="8.5" y1="11" x2="5.5" y2="14.5"/>
             <line x1="11.5" y1="11" x2="14.5" y2="14.5"/>
           </svg>
-          <span class="menu-label">Endpoints</span>
+          <span class="menu-label">Apps</span>
         </a>
       </li>
       <li>
@@ -64,13 +64,13 @@
   </nav>
   <main class="dashboard-main">
     <div class="page-header">
-      <h1>Endpoints</h1>
-      <p>Manage endpoints and authentication keys for the mesh network.</p>
+      <h1>Apps</h1>
+      <p>View apps and generate API keys for apps to register themselves with the mesh network.</p>
     </div>
 
     <section class="content-section" aria-labelledby="auth-keys-heading">
       <div class="section-header">
-        <h2 id="auth-keys-heading">Auth Keys</h2>
+        <h2 id="auth-keys-heading">API Keys</h2>
         <button
           id="generate-key-btn"
           type="button"
@@ -78,7 +78,7 @@
           hx-post="/api/auth/keys"
           hx-swap="none"
         >
-          Generate New Key
+          Generate API Key
         </button>
       </div>
 
@@ -104,7 +104,7 @@
 
     <section class="content-section" aria-labelledby="endpoints-heading">
       <div class="section-header">
-        <h2 id="endpoints-heading">Registered Endpoints</h2>
+        <h2 id="endpoints-heading">Registered Apps</h2>
       </div>
       <div
         id="endpoint-list"
@@ -112,7 +112,7 @@
         hx-trigger="load, every 10s"
         hx-swap="innerHTML"
       >
-        <p class="dashboard-empty">Loading endpoints…</p>
+        <p class="dashboard-empty">Loading apps…</p>
       </div>
     </section>
   </main>
@@ -141,7 +141,7 @@
     document.querySelectorAll('.menu-item').forEach(item => {
       const page = item.getAttribute('data-page');
       if ((page === 'dashboard' && currentPath === '/dashboard') ||
-          (page === 'endpoints' && currentPath === '/endpoints') ||
+          (page === 'apps' && (currentPath === '/apps' || currentPath === '/endpoints')) ||
           (page === 'settings' && currentPath === '/settings')) {
         item.classList.add('active');
       }

--- a/gateway/templates/settings.html
+++ b/gateway/templates/settings.html
@@ -28,7 +28,7 @@
         </a>
       </li>
       <li>
-        <a href="/nodes" class="menu-item" data-page="nodes">
+        <a href="/apps" class="menu-item" data-page="apps">
           <svg class="menu-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="10" cy="10" r="2"/>
             <circle cx="4" cy="4" r="2"/>
@@ -41,7 +41,7 @@
             <line x1="8.5" y1="11" x2="5.5" y2="14.5"/>
             <line x1="11.5" y1="11" x2="14.5" y2="14.5"/>
           </svg>
-          <span class="menu-label">Nodes</span>
+          <span class="menu-label">Apps</span>
         </a>
       </li>
       <li>
@@ -130,7 +130,7 @@
     document.querySelectorAll('.menu-item').forEach(item => {
       const page = item.getAttribute('data-page');
       if ((page === 'dashboard' && currentPath === '/dashboard') ||
-          (page === 'nodes' && currentPath === '/nodes') ||
+          (page === 'apps' && (currentPath === '/apps' || currentPath === '/endpoints')) ||
           (page === 'settings' && currentPath === '/settings')) {
         item.classList.add('active');
       }

--- a/gateway/templates/side_menu.html
+++ b/gateway/templates/side_menu.html
@@ -16,7 +16,7 @@
       </a>
     </li>
     <li>
-      <a href="/nodes" class="menu-item" data-page="nodes">
+      <a href="/apps" class="menu-item" data-page="apps">
         <svg class="menu-icon" width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="10" cy="10" r="2"/>
           <circle cx="4" cy="4" r="2"/>
@@ -29,7 +29,7 @@
           <line x1="8.5" y1="11" x2="5.5" y2="14.5"/>
           <line x1="11.5" y1="11" x2="14.5" y2="14.5"/>
         </svg>
-        <span class="menu-label">Nodes</span>
+        <span class="menu-label">Apps</span>
       </a>
     </li>
     <li>
@@ -192,7 +192,7 @@ body.menu-expanded {
   document.querySelectorAll('.menu-item').forEach(item => {
     const page = item.getAttribute('data-page');
     if ((page === 'dashboard' && currentPath === '/dashboard') ||
-        (page === 'nodes' && currentPath === '/nodes') ||
+        (page === 'apps' && (currentPath === '/apps' || currentPath === '/endpoints')) ||
         (page === 'settings' && currentPath === '/settings')) {
       item.classList.add('active');
     }


### PR DESCRIPTION
## Summary
- require a valid console session for auth-key generate/list/revoke API routes
- keep endpoint registration auth-key validation available for apps while rendering auth-key lists without recursive route calls
- rename the console endpoint/auth-key experience to Apps/API Keys and add /apps as the primary route

## Tests
- rustfmt --edition 2021 --config skip_children=true gateway/src/api/handlers/auth_keys.rs gateway/src/api/handlers/console.rs gateway/src/api/mod.rs --check
- cargo test -p hightower-gateway auth_keys -- --nocapture
- cargo test -p hightower-gateway apps_console_uses_app_and_api_key_language -- --nocapture
- cargo test --workspace --all-targets